### PR TITLE
Fix: Use [+] indexing for multiple groups in AllergySubstanceType ConceptMap

### DIFF
--- a/input/fsh/AllergyConceptMaps.fsh
+++ b/input/fsh/AllergyConceptMaps.fsh
@@ -81,7 +81,7 @@ Usage: #definition
 * status = #draft
 * experimental = true
 
-* group
+* group[+]
   * source = "http://snomed.info/sct"
   * target = "https://fhir-terminology.ohdsi.org"
   * element[+]
@@ -96,7 +96,7 @@ Usage: #definition
       * code = #1728416
       * display = "benzylpenicillin"
       * relationship = #equivalent
-* group
+* group[+]
   * source = "http://www.nlm.nih.gov/research/umls/rxnorm"
   * target = "https://fhir-terminology.ohdsi.org"
   * element[+]


### PR DESCRIPTION

- The AllergySubstanceType instance defined two `* group` blocks without array indexing, causing both to target `group[0]` and conflict on the `source` element.
- Changed both to `* group[+]` so SUSHI generates distinct group entries for the SNOMED CT and RxNorm source systems.