### PR TITLE
Fix concept map errors in EncounterConceptMaps and ConditionConceptMaps

### DIFF
--- a/input/fsh/EncounterConceptMaps.fsh
+++ b/input/fsh/EncounterConceptMaps.fsh
@@ -69,7 +69,7 @@ Description: "An example mapping of FHIR Encounter admission source codes to OMO
   * element[+]
     * code = #emd
     * target
-      * code = #8670
+      * code = #8870
       * display = "Emergency Room - Hospital"
       * relationship = #equivalent
   * element[+]
@@ -114,7 +114,7 @@ Description: "An example mapping of FHIR Encounter admission source codes to OMO
     * code = #rehab
     * target
       * code = #38004254
-      * display = "Rehabilition Clinic/Center"
+      * display = "Rehabilitation Clinic/Center"
       * relationship = #equivalent
   * element[+]
     * code = #other


### PR DESCRIPTION
## Changes

This PR contains some fixes to the content of the ConceptMap's:

- EncounterAdmitSource #emd mapping from OMOP 8670 [[link](https://echidna.fhir.org/browser/code/8670)] ("EU per deciliter", a UCUM unit concept) to 8870 [[link](https://echidna.fhir.org/browser/code/8870)] ("Emergency Room - Hospital", CMS Place of Service), the previous ID was factually the wrong concept
- Typo in EncounterAdmitSource #rehab display: "Rehabilition" → "Rehabilitation" [[link](https://echidna.fhir.org/browser/code/38004254)]

---

## Potential Lingering Issues

There are a number of other *potential* issues that I would like to flag for discussion. These were reviewed using the [echidna.fhir.org](https://echidna.fhir.org) terminology server against the current OMOP vocabulary version (v20260227).

 ### 1. `PatientConceptMaps.fsh` — `#other` → `44814653`
- The mapped concept `44814653` [[link](https://echidna.fhir.org/browser/code/44814653)] is a **non-standard** PCORNet concept whose OMOP display name is "Unknown", not "Other" — so the display label in the FSH is incorrect relative to the concept.
- The OMOP `Gender` vocabulary contains only two standard concepts: `MALE` (8507) and `FEMALE` (8532). There is no standard OMOP equivalent for "other" gender.
- Consideration: use `noMap = true`, or retain with a corrected display and a comment acknowledging non-standard?

### 2. `PatientConceptMaps.fsh` — `#unknown` → `8551`
- Concept `8551` [[link](https://echidna.fhir.org/browser/code/8551)] is **deprecated** (`invalid-reason: D`) and non-standard.
- No standard replacement exists in the Gender vocabulary (same gap as above).
- Consideration: `noMap = true`, or retain with a comment.

> [!NOTE]
> For issues 1 and 2 above, if using a non-standard target concept is acceptable, then it may just be a matter of updating the former to use 8521 ("OTHER") [[link](https://echidna.fhir.org/browser/code/8521)].

### 3. `EncounterConceptMaps.fsh` — `#aadvice` → `32216` [[link](https://echidna.fhir.org/browser/code/32216)] and `#exp` → `32218` [[link](https://echidna.fhir.org/browser/code/32218)]
- Both are **non-standard** UB04 patient discharge status concepts with no standard OMOP equivalent in the Visit domain and no "Maps to" relationship defined.
- "Left against medical advice" and "Expired" don't map cleanly to a care location, which is what [`visit_occurrence.discharged_to_concept_id`](https://ohdsi.github.io/CommonDataModel/cdm54.html#visit_occurrence) in OMOP typically expects.
- Consideration: use `noMap = true`, or retain with a comment acknowledging non-standard.

### 4. `AllergyConceptMaps.fsh` — `AllergyType #food` → `4188027`
- Concept `4188027` [[link](https://echidna.fhir.org/browser/code/4188027)] "Allergy to food" is **non-standard**. Its OMOP "Maps to" relationship points to `43530807` "Allergic disposition".
- However, `43530807` [[link](https://echidna.fhir.org/browser/code/43530807)] is already used in the same map for `#biologic`, meaning updating `#food` to the standard concept would make food and biologic allergies indistinguishable.
- Consideration: retain `4188027` accepting non-standard, or rethink the `#biologic` mapping as well.

### 5. `ConditionConceptMaps.fsh` — SNOMED `312824007` [[link](https://echidna.fhir.org/browser/code/3236609)] → `4195970` [[link](https://echidna.fhir.org/browser/code/4195970)]
- "Family history of cancer of colon" resolves to the **Observation domain** in OMOP, not Condition. This is correct OMOP behaviour (family history is classified as Observation), but implementers querying the Condition table would not find this concept.
- Consideration: unsure on this one - worth flagging nonetheless.